### PR TITLE
bump ratatui version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ repository = "https://github.com/TylerBloom/webatui"
 
 [dependencies]
 base16-palettes = "0.1.0"
-ratatui = { version = "0.26", default-features = false }
+ratatui = { version = "0.28", default-features = false }
 web-sys = { version = "0.3", features = ["Window", "Screen", "TouchEvent", "TouchList", "Touch", "CssStyleSheet", "StyleSheetList", "CssRuleList", "CssRule"] }
 yew = { version = "0.21", features = ["csr"] }

--- a/examples/color_changer/Cargo.toml
+++ b/examples/color_changer/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 webatui = { path = "../../" }
-ratatui = { version = "0.26", default-features = false, features = ["all-widgets"] }
+ratatui = { version = "0.28", default-features = false, features = ["all-widgets"] }
 base16-palettes = { version = "0.1", features = ["gruvbox"] }
 yew = "0.21"

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 webatui = { path = "../../" }
-ratatui = { version = "0.26", default-features = false, features = ["all-widgets"] }
+ratatui = { version = "0.28", default-features = false, features = ["all-widgets"] }
 base16-palettes = "0.1"
 yew = "0.21"

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 webatui = { path = "../../" }
-ratatui = { version = "0.26", default-features = false, features = ["all-widgets"] }
+ratatui = { version = "0.28", default-features = false, features = ["all-widgets"] }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -5,7 +5,8 @@
 use base16_palettes::{Base16Accent, Base16Color, Base16Palette, Base16Shade, Palette, Shade};
 use ratatui::{
     buffer::Cell,
-    prelude::{Backend, Rect},
+    layout::Size,
+    prelude::Backend,
     style::{Color, Modifier, Style, Styled},
 };
 use std::{borrow::Cow, io::Result};
@@ -294,13 +295,11 @@ impl Backend for YewBackend {
         Ok(())
     }
 
-    fn size(&self) -> Result<Rect> {
-        Ok(Rect::new(
-            0,
-            0,
-            self.buffer.first().unwrap().len().saturating_sub(1) as u16,
-            self.buffer.len().saturating_sub(1) as u16,
-        ))
+    fn size(&self) -> Result<Size> {
+        Ok(Size {
+            width: self.buffer.first().unwrap().len().saturating_sub(1) as u16,
+            height: self.buffer.len().saturating_sub(1) as u16,
+        })
     }
 
     fn window_size(&mut self) -> Result<ratatui::backend::WindowSize> {
@@ -310,6 +309,18 @@ impl Backend for YewBackend {
     fn flush(&mut self) -> Result<()> {
         self.prerender();
         Ok(())
+    }
+
+    fn get_cursor_position(&mut self) -> Result<ratatui::prelude::Position> {
+        todo!()
+    }
+
+    fn set_cursor_position<P: Into<ratatui::prelude::Position>>(
+        &mut self,
+        position: P,
+    ) -> Result<()> {
+        let _ = position;
+        todo!()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,8 +281,8 @@ impl<A: TerminalApp> Component for WebTerminal<A> {
 
     fn view(&self, ctx: &Context<Self>) -> yew::Html {
         let mut term = self.term.borrow_mut();
-        let area = term.size().unwrap();
-        term.draw(|frame| self.app.render(area, frame)).unwrap();
+        term.draw(|frame| self.app.render(frame.area(), frame))
+            .unwrap();
         term.backend_mut()
             .hydrate(|span| self.app.hydrate(ctx, span))
     }


### PR DESCRIPTION
There seemed to be some breaking changes between `0.26` and `0.28` of  `ratatui`.

Currently I am experimenting with adding browser support to the terminal application I built on `0.28` and these are the adjustments I had to make so far to get `webatui` and its examples running, so I wanted to send them over.

Feel free to disregard if there are no plans for further changes here. Thank you 😄 